### PR TITLE
Add ability to define field specific search filter

### DIFF
--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -122,7 +122,12 @@ class DatatableMixin(MultipleObjectMixin):
                     for component_name in column.fields + column.search_fields:
                         field_queries = [ ]  # Queries generated to search this database field for the search term
                         field = resolve_orm_path( self.get_model(), component_name )
-                        if field.choices:
+
+                        field_method_name = 'search_' + field.name
+                        if hasattr(self, field_method_name):
+                            # Call field specific method to get the field queries
+                            field_queries.append(getattr(self, field_method_name)(field, term))
+                        elif field.choices:
                             # Query the database for the database value rather than display value
                             choices = field.get_flatchoices()
                             length = len(choices)


### PR DESCRIPTION
Previously field queries were made in a really opinionated way. It was hard to alter the query made against the database.

Now there is a way to define a custom query for each field by defining `search_field_name` method.